### PR TITLE
Use rpath liberally

### DIFF
--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -24,6 +24,10 @@ else
 	CFLAGS += -D_XOPEN_SOURCE=700
 	CXXFLAGS += -D_XOPEN_SOURCE=700
     LIB_SUFFIX = so
+    # Special case for conda build :\...
+    ifneq ($(origin CONDA_PREFIX),undefined)
+        LDFLAGS += -Wl,-rpath=$(CONDA_PREFIX)/lib
+    endif
 endif
 PREFIX ?= $(HOME)
 BIN_PATH ?= $(PREFIX)/bin

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -24,10 +24,7 @@ else
 	CFLAGS += -D_XOPEN_SOURCE=700
 	CXXFLAGS += -D_XOPEN_SOURCE=700
     LIB_SUFFIX = so
-    # Special case for conda build :\...
-    ifneq ($(origin CONDA_PREFIX),undefined)
-        LDFLAGS += -Wl,-rpath=$(CONDA_PREFIX)/lib
-    endif
+    LDFLAGS += -Wl,-rpath=$(PREFIX)/lib
 endif
 PREFIX ?= $(HOME)
 BIN_PATH ?= $(PREFIX)/bin


### PR DESCRIPTION
I can't think of a downside to this and it keeps stuff working when LD_LIBRARY_PATH isn't twiddled exactly the same way as build time. Thoughts?