### PR TITLE
Changes to build with latest upstream LAPACK 

### DIFF
--- a/include/math/templateLapack.hpp
+++ b/include/math/templateLapack.hpp
@@ -33,6 +33,9 @@ extern "C"
 {
 #ifdef MXLIB_MKL
 
+   #define MKL_Complex8 float _Complex
+   #define MKL_Complex16 double _Complex
+
    #include <mkl.h>
 
 #else

--- a/include/math/templateLapack.hpp
+++ b/include/math/templateLapack.hpp
@@ -33,10 +33,6 @@ extern "C"
 {
 #ifdef MXLIB_MKL
 
-   #define MKL_Complex8 std::complex<float>
-   #define MKL_Complex16 std::complex<double>
-        
-
    #include <mkl.h>
 
 #else

--- a/source/math/templateLapack.cpp
+++ b/source/math/templateLapack.cpp
@@ -81,7 +81,7 @@ MXLAPACK_INT potrf<double> ( char UPLO, MXLAPACK_INT N, double * A, MXLAPACK_INT
 template<>
 MXLAPACK_INT potrf<std::complex<float>> ( char UPLO, MXLAPACK_INT N, std::complex<float> * A, MXLAPACK_INT LDA, MXLAPACK_INT &INFO )
 {
-   cpotrf_(&UPLO, &N, A, &LDA, &INFO
+   cpotrf_(&UPLO, &N, (float _Complex*)A, &LDA, &INFO
    #ifdef LAPACK_FORTRAN_STRLEN_END
    , 1
    #endif
@@ -93,7 +93,7 @@ MXLAPACK_INT potrf<std::complex<float>> ( char UPLO, MXLAPACK_INT N, std::comple
 template<>
 MXLAPACK_INT potrf<std::complex<double>> ( char UPLO, MXLAPACK_INT N, std::complex<double> * A, MXLAPACK_INT LDA, MXLAPACK_INT &INFO )
 {
-   zpotrf_(&UPLO, &N, A, &LDA, &INFO
+   zpotrf_(&UPLO, &N, (double _Complex*)A, &LDA, &INFO
    #ifdef LAPACK_FORTRAN_STRLEN_END
    , 1
    #endif

--- a/source/math/templateLapack.cpp
+++ b/source/math/templateLapack.cpp
@@ -81,7 +81,9 @@ MXLAPACK_INT potrf<double> ( char UPLO, MXLAPACK_INT N, double * A, MXLAPACK_INT
 template<>
 MXLAPACK_INT potrf<std::complex<float>> ( char UPLO, MXLAPACK_INT N, std::complex<float> * A, MXLAPACK_INT LDA, MXLAPACK_INT &INFO )
 {
-   cpotrf_(&UPLO, &N, (float _Complex*)A, &LDA, &INFO
+   cpotrf_(&UPLO, &N,
+   (float _Complex*)A,
+   &LDA, &INFO
    #ifdef LAPACK_FORTRAN_STRLEN_END
    , 1
    #endif
@@ -93,7 +95,9 @@ MXLAPACK_INT potrf<std::complex<float>> ( char UPLO, MXLAPACK_INT N, std::comple
 template<>
 MXLAPACK_INT potrf<std::complex<double>> ( char UPLO, MXLAPACK_INT N, std::complex<double> * A, MXLAPACK_INT LDA, MXLAPACK_INT &INFO )
 {
-   zpotrf_(&UPLO, &N, (double _Complex*)A, &LDA, &INFO
+   zpotrf_(&UPLO, &N,
+   (double _Complex*)A,
+   &LDA, &INFO
    #ifdef LAPACK_FORTRAN_STRLEN_END
    , 1
    #endif

--- a/source/math/templateLapack.cpp
+++ b/source/math/templateLapack.cpp
@@ -36,20 +36,32 @@ namespace math
 template<>
 float lamch<float>(char CMACH)
 { 
-   return  slamch_ (&CMACH);
+   return  slamch_ (&CMACH
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1
+   #endif
+   );
 }
 
 // Double specialization of lamch, a wrapper for Lapack DLAMCH
 template<>
 double lamch<double>(char CMACH)
 { 
-   return  dlamch_ (&CMACH);
+   return  dlamch_ (&CMACH
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1
+   #endif
+   );
 }
 
 template<>
 MXLAPACK_INT potrf<float> ( char UPLO, MXLAPACK_INT N, float * A, MXLAPACK_INT LDA, MXLAPACK_INT &INFO )
 {
-   spotrf_(&UPLO, &N, A, &LDA, &INFO);
+   spotrf_(&UPLO, &N, A, &LDA, &INFO
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1
+   #endif
+   );
    
    return INFO;
 }
@@ -57,7 +69,11 @@ MXLAPACK_INT potrf<float> ( char UPLO, MXLAPACK_INT N, float * A, MXLAPACK_INT L
 template<>
 MXLAPACK_INT potrf<double> ( char UPLO, MXLAPACK_INT N, double * A, MXLAPACK_INT LDA, MXLAPACK_INT &INFO )
 {
-   dpotrf_(&UPLO, &N, A, &LDA, &INFO);
+   dpotrf_(&UPLO, &N, A, &LDA, &INFO
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1
+   #endif
+   );
    
    return INFO;
 }
@@ -65,7 +81,11 @@ MXLAPACK_INT potrf<double> ( char UPLO, MXLAPACK_INT N, double * A, MXLAPACK_INT
 template<>
 MXLAPACK_INT potrf<std::complex<float>> ( char UPLO, MXLAPACK_INT N, std::complex<float> * A, MXLAPACK_INT LDA, MXLAPACK_INT &INFO )
 {
-   cpotrf_(&UPLO, &N, A, &LDA, &INFO);
+   cpotrf_(&UPLO, &N, A, &LDA, &INFO
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1
+   #endif
+   );
    
    return INFO;
 }
@@ -73,7 +93,11 @@ MXLAPACK_INT potrf<std::complex<float>> ( char UPLO, MXLAPACK_INT N, std::comple
 template<>
 MXLAPACK_INT potrf<std::complex<double>> ( char UPLO, MXLAPACK_INT N, std::complex<double> * A, MXLAPACK_INT LDA, MXLAPACK_INT &INFO )
 {
-   zpotrf_(&UPLO, &N, A, &LDA, &INFO);
+   zpotrf_(&UPLO, &N, A, &LDA, &INFO
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1
+   #endif
+   );
    
    return INFO;
 }
@@ -82,7 +106,11 @@ template<>
 MXLAPACK_INT sytrd<float>( char UPLO, MXLAPACK_INT N, float * A, MXLAPACK_INT LDA, float *D, float *E, float *TAU, float *WORK, MXLAPACK_INT LWORK, MXLAPACK_INT INFO)
 {
   
-   ssytrd_(&UPLO, &N, A, &LDA, D, E, TAU, WORK, &LWORK, &INFO);
+   ssytrd_(&UPLO, &N, A, &LDA, D, E, TAU, WORK, &LWORK, &INFO
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1
+   #endif
+   );
    
    return INFO;
 }
@@ -91,7 +119,11 @@ template<>
 MXLAPACK_INT sytrd<double>( char UPLO, MXLAPACK_INT N, double * A, MXLAPACK_INT LDA, double *D, double *E, double *TAU, double *WORK, MXLAPACK_INT LWORK, MXLAPACK_INT INFO)
 {
   
-   dsytrd_(&UPLO, &N, A, &LDA, D, E, TAU, WORK, &LWORK, &INFO);
+   dsytrd_(&UPLO, &N, A, &LDA, D, E, TAU, WORK, &LWORK, &INFO
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1
+   #endif
+   );
    
    return INFO;
 }
@@ -107,7 +139,11 @@ MXLAPACK_INT syevr<float> ( char JOBZ, char RANGE, char UPLO, MXLAPACK_INT N, fl
    
    ssyevr_ (&JOBZ, &RANGE, &UPLO, &N, A, &LDA, &VL, &VU,
            &IL, &IU, &ABSTOL, M, W, Z, &LDZ, ISUPPZ,
-           WORK, &LWORK, IWORK, &LIWORK, &INFO);
+           WORK, &LWORK, IWORK, &LIWORK, &INFO
+           #ifdef LAPACK_FORTRAN_STRLEN_END
+           , 1, 1, 1
+           #endif
+           );
 
    return  INFO;
 }
@@ -123,7 +159,11 @@ MXLAPACK_INT syevr<double> ( char JOBZ, char RANGE, char UPLO, MXLAPACK_INT N, d
    
    dsyevr_ (&JOBZ, &RANGE, &UPLO, &N, A, &LDA, &VL, &VU,
            &IL, &IU, &ABSTOL, M, W, Z, &LDZ, ISUPPZ,
-           WORK, &LWORK, IWORK, &LIWORK, &INFO);
+           WORK, &LWORK, IWORK, &LIWORK, &INFO
+           #ifdef LAPACK_FORTRAN_STRLEN_END
+           , 1, 1, 1
+           #endif
+   );
 
    return  INFO;
 }
@@ -135,7 +175,11 @@ MXLAPACK_INT gesvd<float>( char JOBU, char JOBVT, MXLAPACK_INT M, MXLAPACK_INT N
 {
    MXLAPACK_INT INFO;
    
-   sgesvd_(&JOBU, &JOBVT, &M, &N, A, &LDA, S, U, &LDU,VT, &LDVT, WORK, &LWORK, &INFO);
+   sgesvd_(&JOBU, &JOBVT, &M, &N, A, &LDA, S, U, &LDU,VT, &LDVT, WORK, &LWORK, &INFO
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1, 1
+   #endif
+   );
    
    return INFO;
 }
@@ -147,7 +191,11 @@ MXLAPACK_INT gesvd<double>( char JOBU, char JOBVT, MXLAPACK_INT M, MXLAPACK_INT 
 {
    MXLAPACK_INT INFO;
    
-   dgesvd_(&JOBU, &JOBVT, &M, &N, A, &LDA, S, U, &LDU,VT, &LDVT, WORK, &LWORK, &INFO);
+   dgesvd_(&JOBU, &JOBVT, &M, &N, A, &LDA, S, U, &LDU,VT, &LDVT, WORK, &LWORK, &INFO
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1, 1
+   #endif
+   );
    
    return INFO;
 }
@@ -156,7 +204,11 @@ MXLAPACK_INT gesvd<double>( char JOBU, char JOBVT, MXLAPACK_INT M, MXLAPACK_INT 
 template<>
 MXLAPACK_INT gesdd<float>(char JOBZ, MXLAPACK_INT M, MXLAPACK_INT N, float *A, MXLAPACK_INT LDA, float *S, float * U, MXLAPACK_INT LDU, float * VT, MXLAPACK_INT LDVT, float *WORK, MXLAPACK_INT  LWORK, MXLAPACK_INT * IWORK, MXLAPACK_INT INFO)
 {
-   sgesdd_(&JOBZ,&M,&N,A,&LDA,S,U,&LDU,VT,&LDVT,WORK,&LWORK,IWORK,&INFO);
+   sgesdd_(&JOBZ,&M,&N,A,&LDA,S,U,&LDU,VT,&LDVT,WORK,&LWORK,IWORK,&INFO
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1
+   #endif
+   );
    
    return INFO;
 }
@@ -165,7 +217,11 @@ MXLAPACK_INT gesdd<float>(char JOBZ, MXLAPACK_INT M, MXLAPACK_INT N, float *A, M
 template<>
 MXLAPACK_INT gesdd<double>(char JOBZ, MXLAPACK_INT M, MXLAPACK_INT N, double *A, MXLAPACK_INT LDA, double *S, double * U, MXLAPACK_INT LDU, double * VT, MXLAPACK_INT LDVT, double *WORK, MXLAPACK_INT  LWORK, MXLAPACK_INT * IWORK, MXLAPACK_INT INFO)
 {
-   dgesdd_(&JOBZ,&M,&N,A,&LDA,S,U,&LDU,VT,&LDVT,WORK,&LWORK,IWORK,&INFO);
+   dgesdd_(&JOBZ,&M,&N,A,&LDA,S,U,&LDU,VT,&LDVT,WORK,&LWORK,IWORK,&INFO
+   #ifdef LAPACK_FORTRAN_STRLEN_END
+   , 1
+   #endif
+   );
    
    return INFO;
 }

--- a/source/vendor/levmar-2.6/Makefile
+++ b/source/vendor/levmar-2.6/Makefile
@@ -8,26 +8,11 @@ CONFIGFLAGS=-ULINSOLVERS_RETAIN_MEMORY
 
 
 CFLAGS=$(CONFIGFLAGS) $(ARCHFLAGS) -O3 -ffast-math -funroll-loops -Wall -fPIC
-
-### ATLAS:
-#LAPACKLIBS_PATH=/usr/local/atlas/lib
-#LAPACKLIBS=-llapack -lcblas -lf77blas  -latlas -lgfortran
-
-### MKL:
-LAPACKLIBS_PATH=${MKLROOT}/lib/intel64
-CFLAGS+=-m64
-LAPACKLIBS=-Wl,--no-as-needed -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl
-
-
-
-LDFLAGS=-L$(LAPACKLIBS_PATH) -L.
 LIBOBJS=lm.o Axb.o misc.o lmlec.o lmbc.o lmblec.o lmbleic.o
 LIBSRCS=lm.c Axb.c misc.c lmlec.c lmbc.c lmblec.c lmbleic.c
 
 AR=ar -r
 RANLIB=ar -s
-
-LIBS=$(LAPACKLIBS)
 
 all: liblevmar.a
 


### PR DESCRIPTION
Thanks to https://github.com/ITensor/ITensor/pull/413 we know how to handle the function signature change in LAPACK.

Also casts to `(double _Complex*)` from `std::complex<double>` (and correspondingly for `float`) to build with vanilla LAPACK's headers on Linux.

Also cleans up levmar Makefile.